### PR TITLE
treat “-“ in service types as valid protocol

### DIFF
--- a/zerxconf/src/main/java/it/ennova/zerxconf/utils/NsdUtils.java
+++ b/zerxconf/src/main/java/it/ennova/zerxconf/utils/NsdUtils.java
@@ -19,7 +19,7 @@ public class NsdUtils {
     /**
      * This constant is the one that matches the specification of the ZeroConf protocol
      */
-    public static final String NSD_URL_PATTERN = "^_[\\w]+\\._((udp)|(tcp))\\.[(local)\\.]*$";
+    public static final String NSD_URL_PATTERN = "^_[\\w]+(-[\\w]+)*\\._((udp)|(tcp))\\.[(local)\\.]*$";
 
     /**
      * This method is the one that will build the {@link NsdServiceInfo} from the


### PR DESCRIPTION
Add support for service types like (_udisks-ssh._tcp, _xbmc-jsonrpc-h._tcp, _xbmc-events._udp) which have "-" in service name.